### PR TITLE
34 feature request support raw queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ version = "0.6.1"
 dependencies = [
  "async-recursion",
  "clap",
- "cornucopia_client 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cornucopia_client 0.1.0",
  "deadpool-postgres",
  "eui48",
  "heck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ version = "0.6.1"
 dependencies = [
  "async-recursion",
  "clap",
- "cornucopia_client 0.2.0",
+ "cornucopia_client 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "deadpool-postgres",
  "eui48",
  "futures",
@@ -182,7 +182,7 @@ dependencies = [
 name = "cornucopia-example-auto-build"
 version = "0.1.0"
 dependencies = [
- "cornucopia_client 0.1.0",
+ "cornucopia_client 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "deadpool-postgres",
  "tokio",
  "tokio-postgres",
@@ -192,7 +192,7 @@ dependencies = [
 name = "cornucopia-example-basic"
 version = "0.1.0"
 dependencies = [
- "cornucopia_client 0.2.0",
+ "cornucopia_client 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "deadpool-postgres",
  "futures",
  "postgres-types",
@@ -202,9 +202,7 @@ dependencies = [
 
 [[package]]
 name = "cornucopia_client"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c80d61fbc0276d93c0b5df6b2d9c1570a55ff183c71e42c7a6f904eecd8780"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "deadpool-postgres",
@@ -215,6 +213,8 @@ dependencies = [
 [[package]]
 name = "cornucopia_client"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea767c5bfc64ebeec00abe9a329d630e04a91f420761248cbd57c3ca11cd7cec"
 dependencies = [
  "async-trait",
  "deadpool-postgres",
@@ -506,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
@@ -578,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "num_threads"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,9 +161,10 @@ version = "0.6.1"
 dependencies = [
  "async-recursion",
  "clap",
- "cornucopia_client 0.1.0",
+ "cornucopia_client 0.2.0",
  "deadpool-postgres",
  "eui48",
+ "futures",
  "heck",
  "pest",
  "pest_derive",
@@ -181,7 +182,7 @@ dependencies = [
 name = "cornucopia-example-auto-build"
 version = "0.1.0"
 dependencies = [
- "cornucopia_client 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cornucopia_client 0.1.0",
  "deadpool-postgres",
  "tokio",
  "tokio-postgres",
@@ -191,19 +192,10 @@ dependencies = [
 name = "cornucopia-example-basic"
 version = "0.1.0"
 dependencies = [
- "cornucopia_client 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cornucopia_client 0.2.0",
  "deadpool-postgres",
+ "futures",
  "postgres-types",
- "tokio",
- "tokio-postgres",
-]
-
-[[package]]
-name = "cornucopia_client"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "deadpool-postgres",
  "tokio",
  "tokio-postgres",
 ]
@@ -213,6 +205,16 @@ name = "cornucopia_client"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55c80d61fbc0276d93c0b5df6b2d9c1570a55ff183c71e42c7a6f904eecd8780"
+dependencies = [
+ "async-trait",
+ "deadpool-postgres",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "cornucopia_client"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "deadpool-postgres",
@@ -899,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f972498cf015f7c0746cac89ebe1d6ef10c293b94175a243a2d9442c163d9944"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["postgresql", "query", "generator", "sql", "tokio-postgres"]
 members = ["examples/*", "cornucopia_client"]
 
 [dependencies]
-cornucopia_client = "0.1.0"
+cornucopia_client = {path = "./cornucopia_client"}
 tokio = { version = "1.18.1", features = ["full"] }
 deadpool-postgres = "0.10.2"
 tokio-postgres = { version = "0.7.6", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["postgresql", "query", "generator", "sql", "tokio-postgres"]
 members = ["examples/*", "cornucopia_client"]
 
 [dependencies]
-cornucopia_client = { path = "./cornucopia_client" }
+cornucopia_client = "0.2.0"
 futures = "0.3.21"
 tokio = { version = "1.18.1", features = ["full"] }
 deadpool-postgres = "0.10.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ keywords = ["postgresql", "query", "generator", "sql", "tokio-postgres"]
 members = ["examples/*", "cornucopia_client"]
 
 [dependencies]
-cornucopia_client = {path = "./cornucopia_client"}
+cornucopia_client = { path = "./cornucopia_client" }
+futures = "0.3.21"
 tokio = { version = "1.18.1", features = ["full"] }
 deadpool-postgres = "0.10.2"
 tokio-postgres = { version = "0.7.6", features = [
@@ -25,7 +26,7 @@ tokio-postgres = { version = "0.7.6", features = [
 ] }
 postgres-types = { version = "0.2.3", features = ["derive"] }
 serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.80"
+serde_json = "1.0.81"
 time = { version = "0.3.9", features = ["parsing"] }
 uuid = "1.0.0"
 eui48 = "1.1.0"

--- a/README.md
+++ b/README.md
@@ -205,6 +205,11 @@ pub async fn authors<T: GenericClient>(client: &T) -> Result<Vec<ExampleQuery>, 
 }
 ```
 
+###### Raw return
+> `#`
+
+This return type indicates that the query should return a `RowStream`. This is often less desirable, as you don't get type inference of the actual return type, but it is offered as a convenience for those few queries that absolutely need a `RowStream`. You cannot use a quantifier with this return type.
+
 #### Quantifier
 > ` ` (no quantifier), `?`, `*`
 

--- a/README.md
+++ b/README.md
@@ -92,14 +92,14 @@ The code block below shows what your dependencies might look like with every fea
 tokio = { version = "1.18.1", features = ["full"] }
 deadpool-postgres = { version = "0.10.2" }
 postgres-types = { version = "0.2.3", features = ["derive"] }
+cornucopia_client = "0.2.0"
+futures = "0.3.21"
 tokio-postgres = { version = "0.7.6", features = [
     "with-serde_json-1",
     "with-time-0_3",
     "with-uuid-1",
     "with-eui48-1",
 ] }
-cornucopia_client = "0.1.0"
-futures = "0.3.21"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 time = "0.3.9"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,23 @@ To use `docker` on Linux, **non-sudo users need to be in the docker group**. For
 No special installation steps are needed for `podman`, but note that you will need to pass a CLI flag (`-p` or `--podman`) because `cornucopia` defaults to `docker`.
 
 ### Dependencies
-Cornucopia will generate queries powered by the `tokio` runtime through `tokio-postgres`, so you will need add the latest version of these to your `Cargo.toml`. If you wish to use pooled connections, you'll also need `deadpool-postgres`. You'll also need the `postgres_types` crate if you want to work with custom PostgreSQL types. Finally, you will need the `cornucopia_client` crate, which has only one item: the `GenericClient` trait. You might need more dependencies depending on which features you intend to use. The code block below shows what your dependencies might look like with every feature that `cornucopia` supports enabled:
+#### Required
+Cornucopia will generate queries powered by the `tokio` runtime through `tokio-postgres`, and it also uses some extended async features from `futures` so you will need add the latest version of these to your `Cargo.toml`. Finally, you will need the `cornucopia_client` crate, which has only one item: the `GenericClient` trait.
+
+#### Optional
+* Pooled connections: `deadpool-postgres`. 
+* Custom PostgreSQL user types: `postgres_types`.
+
+#### Extra types using `tokio_postgres` features
+| Crate        | available types                                    | `tokio_postgres` feature |
+| ------------ | -------------------------------------------------- | ------------------------ |
+| `serde_json` | `Value`                                            | `with-serde_json-1`      |
+| `time`       | `Date` `Time` `PrimitiveDateTime` `OffsetDateTime` | `with-time-0_3`          |
+| `uuid`       | `Uuid`                                             | `with-uuid-1`            |
+| `eui48`      | `MacAddress`                                       | `with-eui48-1`           |
+
+#### Full dependencies
+The code block below shows what your dependencies might look like with every feature that `cornucopia` supports enabled:
 ```toml
 # Cargo.toml
 [dependencies]
@@ -83,8 +99,9 @@ tokio-postgres = { version = "0.7.6", features = [
     "with-eui48-1",
 ] }
 cornucopia_client = "0.1.0"
+futures = "0.3.21"
 serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.80"
+serde_json = "1.0.81"
 time = "0.3.9"
 uuid = "1.0.0"
 eui48 = "1.1.0"
@@ -205,21 +222,17 @@ pub async fn authors<T: GenericClient>(client: &T) -> Result<Vec<ExampleQuery>, 
 }
 ```
 
-###### Raw return
-> `#`
-
-This return type indicates that the query should return a `RowStream`. This is often less desirable, as you don't get type inference of the actual return type, but it is offered as a convenience for those few queries that absolutely need a `RowStream`. You cannot use a quantifier with this return type.
-
 #### Quantifier
-> ` ` (no quantifier), `?`, `*`
+> ` ` (no quantifier), `?`, `*`, `#`
 
-The quantifier indicates the expected number of rows returned by a query. If no quantifier is specified, then it is assumed that only one record will be returned. Using `*` and `?` (corresponding to the "zero or more" and "zero or one" quantifiers) will wrap the resulting Rust type in a `Vec` and `Option` respectively. To sum it up:
+The quantifier indicates the expected number of rows returned by a query. No more than one quantifier can be used, and if no quantifier is specified, then it is assumed that only one record will be returned. Using `*` and `?` (corresponding to the "zero or more" and "zero or one" quantifiers) will wrap the resulting Rust type in a `Vec` and `Option` respectively. Additionally, there is the stream identifier `#` which is very similar to `*`, but produces a `Stream` instead of a `Vec` To sum it up:
 
 * ` ` (no quantifier) results in `T`
 * `*` results in `Vec<T>`
 * `?` results in `Option<T>`
+* `#` results in `impl Stream<Item = Result<T, Error>>`
 
-Note that explicit returns' columns  can be marked as nullable with `?`, while the `?` quantifier acts on the whole row.
+Note that explicit return columns can be marked as nullable with `?`, while the `?` quantifier acts on the whole row.
 
 ### Transactions
 Generated queries take a `GenericClient` as parameter, which accepts both `Client`s and `Transaction`s. That means you can use the same generated queries for both single statements and transactions.

--- a/cornucopia_client/Cargo.toml
+++ b/cornucopia_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cornucopia_client"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "Generic client trait for Cornucopia users"

--- a/cornucopia_client/src/lib.rs
+++ b/cornucopia_client/src/lib.rs
@@ -102,7 +102,7 @@ impl GenericClient for Transaction<'_> {
         I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator,
     {
-        PgTransaction::query_raw(&self, statement, params).await
+        PgTransaction::query_raw(self, statement, params).await
     }
 }
 
@@ -163,7 +163,7 @@ impl GenericClient for PgTransaction<'_> {
         I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator,
     {
-        PgTransaction::query_raw(&self, statement, params).await
+        PgTransaction::query_raw(self, statement, params).await
     }
 }
 
@@ -224,7 +224,7 @@ impl GenericClient for Client {
         I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator,
     {
-        PgClient::query_raw(&self, statement, params).await
+        PgClient::query_raw(self, statement, params).await
     }
 }
 
@@ -285,6 +285,6 @@ impl GenericClient for PgClient {
         I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator,
     {
-        PgClient::query_raw(&self, statement, params).await
+        PgClient::query_raw(self, statement, params).await
     }
 }

--- a/cornucopia_client/src/lib.rs
+++ b/cornucopia_client/src/lib.rs
@@ -1,8 +1,11 @@
 use async_trait::async_trait;
 use deadpool_postgres::{Client, ClientWrapper, Transaction};
-use tokio_postgres::{Client as PgClient, Error, Statement, Transaction as PgTransaction};
+use tokio_postgres::{
+    types::BorrowToSql, Client as PgClient, Error, RowStream, Statement, ToStatement,
+    Transaction as PgTransaction,
+};
 
-#[async_trait]
+#[async_trait(?Send)]
 pub trait GenericClient {
     async fn prepare(&self, query: &str) -> Result<Statement, Error>;
     async fn execute<T>(
@@ -33,9 +36,16 @@ pub trait GenericClient {
     ) -> Result<Vec<tokio_postgres::Row>, Error>
     where
         T: ?Sized + tokio_postgres::ToStatement + Sync + Send;
+
+    async fn query_raw<T, P, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
+    where
+        T: ?Sized + ToStatement,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P>,
+        I::IntoIter: ExactSizeIterator;
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl GenericClient for Transaction<'_> {
     async fn prepare(&self, query: &str) -> Result<Statement, Error> {
         Transaction::prepare_cached(self, query).await
@@ -84,9 +94,19 @@ impl GenericClient for Transaction<'_> {
     {
         PgTransaction::query(self, query, params).await
     }
+
+    async fn query_raw<T, P, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
+    where
+        T: ?Sized + ToStatement,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        PgTransaction::query_raw(&self, statement, params).await
+    }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl GenericClient for PgTransaction<'_> {
     async fn prepare(&self, query: &str) -> Result<Statement, Error> {
         PgTransaction::prepare(self, query).await
@@ -135,9 +155,19 @@ impl GenericClient for PgTransaction<'_> {
     {
         PgTransaction::query(self, query, params).await
     }
+
+    async fn query_raw<T, P, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
+    where
+        T: ?Sized + ToStatement,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        PgTransaction::query_raw(&self, statement, params).await
+    }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl GenericClient for Client {
     async fn prepare(&self, query: &str) -> Result<Statement, Error> {
         ClientWrapper::prepare_cached(self, query).await
@@ -186,9 +216,19 @@ impl GenericClient for Client {
     {
         PgClient::query(self, query, params).await
     }
+
+    async fn query_raw<T, P, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
+    where
+        T: ?Sized + ToStatement,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        PgClient::query_raw(&self, statement, params).await
+    }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl GenericClient for PgClient {
     async fn prepare(&self, query: &str) -> Result<Statement, Error> {
         PgClient::prepare(self, query).await
@@ -236,5 +276,15 @@ impl GenericClient for PgClient {
         T: ?Sized + tokio_postgres::ToStatement + Sync + Send,
     {
         PgClient::query(self, query, params).await
+    }
+
+    async fn query_raw<T, P, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
+    where
+        T: ?Sized + ToStatement,
+        P: BorrowToSql,
+        I: IntoIterator<Item = P>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        PgClient::query_raw(&self, statement, params).await
     }
 }

--- a/examples/auto_build/Cargo.toml
+++ b/examples/auto_build/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 [dependencies]
 tokio = { version = "1.18.1", features = ["full"] }
 tokio-postgres = "0.7.6"
-cornucopia_client = "0.1.0"
+cornucopia_client = "0.2.0"
 deadpool-postgres = "0.10.2"

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [dependencies]
 tokio = { version = "1.18.1", features = ["full"] }
 deadpool-postgres = "0.10.2"
+futures = "0.3.21"
 postgres-types = { version = "0.2.3", features = ["derive"] }
 tokio-postgres = "0.7.6"
-cornucopia_client = "0.1.0"
+cornucopia_client = { path = "../../cornucopia_client" }

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -9,4 +9,4 @@ deadpool-postgres = "0.10.2"
 futures = "0.3.21"
 postgres-types = { version = "0.2.3", features = ["derive"] }
 tokio-postgres = "0.7.6"
-cornucopia_client = { path = "../../cornucopia_client" }
+cornucopia_client = "0.2.0"

--- a/examples/basic/queries/module_2.sql
+++ b/examples/basic/queries/module_2.sql
@@ -4,6 +4,12 @@ SELECT
 FROM
     Author;
 
+--! authors_stream()#
+SELECT
+    *
+FROM
+    Author;
+
 --! books() {title}*
 SELECT
     Title

--- a/examples/basic/src/cornucopia.rs
+++ b/examples/basic/src/cornucopia.rs
@@ -2,17 +2,7 @@
 
 pub mod types {
     pub mod public {
-        use postgres_types::{FromSql, ToSql};
-        #[derive(Debug, ToSql, FromSql)]
-        #[postgres(name = "spongebob_character")]
-        #[derive(Clone, Copy, PartialEq, Eq)]
-        pub enum SpongebobCharacter {
-            Bob,
-            Patrick,
-            Squidward,
-        }
-
-        #[derive(Debug, ToSql, FromSql)]
+        #[derive(Debug, postgres_types::ToSql, postgres_types::FromSql)]
         #[postgres(name = "custom_composite")]
         #[derive(Clone)]
         pub struct CustomComposite {
@@ -20,15 +10,24 @@ pub mod types {
             pub name: String,
             pub persona: super::public::SpongebobCharacter,
         }
+
+        #[derive(Debug, postgres_types::ToSql, postgres_types::FromSql)]
+        #[postgres(name = "spongebob_character")]
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        pub enum SpongebobCharacter {
+            Bob,
+            Patrick,
+            Squidward,
+        }
     }
 }
 
 pub mod queries {
     pub mod module_1 {
-        use cornucopia_client::GenericClient;
-        use tokio_postgres::Error;
-
-        pub async fn insert_book<T: GenericClient>(client: &T, title: &str) -> Result<(), Error> {
+        pub async fn insert_book<T: cornucopia_client::GenericClient>(
+            client: &T,
+            title: &str,
+        ) -> Result<(), tokio_postgres::Error> {
             let stmt = client
                 .prepare(
                     "INSERT INTO Book (title)
@@ -37,18 +36,15 @@ VALUES ($1);
                 )
                 .await?;
             let _ = client.execute(&stmt, &[&title]).await?;
-
             Ok(())
         }
     }
 
     pub mod module_2 {
-        use cornucopia_client::GenericClient;
-        use tokio_postgres::Error;
-
-        pub async fn authors<T: GenericClient>(
+        pub async fn authors<T: cornucopia_client::GenericClient>(
             client: &T,
-        ) -> Result<Vec<(i32, String, String)>, Error> {
+        ) -> Result<Vec<(i32, String, String)>, tokio_postgres::Error> {
+            use futures::{StreamExt, TryStreamExt};
             let stmt = client
                 .prepare(
                     "SELECT
@@ -58,27 +54,60 @@ Author;
 ",
                 )
                 .await?;
-            let res = client.query(&stmt, &[]).await?;
-
-            let return_value = res
-                .iter()
+            let res = client
+                .query_raw(&stmt, std::iter::empty::<i32>())
+                .await?
                 .map(|res| {
-                    let return_value_0: i32 = res.get(0);
-                    let return_value_1: String = res.get(1);
-                    let return_value_2: String = res.get(2);
-                    (return_value_0, return_value_1, return_value_2)
+                    res.map(|res| {
+                        let return_value_0: i32 = res.get(0);
+                        let return_value_1: String = res.get(1);
+                        let return_value_2: String = res.get(2);
+                        (return_value_0, return_value_1, return_value_2)
+                    })
                 })
-                .collect::<Vec<(i32, String, String)>>();
-            Ok(return_value)
+                .try_collect()
+                .await?;
+            Ok(res)
+        }
+
+        pub async fn authors_stream<T: cornucopia_client::GenericClient>(
+            client: &T,
+        ) -> Result<
+            impl futures::Stream<Item = Result<(i32, String, String), tokio_postgres::Error>>,
+            tokio_postgres::Error,
+        > {
+            use futures::{StreamExt, TryStreamExt};
+            let stmt = client
+                .prepare(
+                    "SELECT
+*
+FROM
+Author;
+",
+                )
+                .await?;
+            let row_stream = client
+                .query_raw(&stmt, std::iter::empty::<i32>())
+                .await?
+                .map(|res| {
+                    res.map(|res| {
+                        let return_value_0: i32 = res.get(0);
+                        let return_value_1: String = res.get(1);
+                        let return_value_2: String = res.get(2);
+                        (return_value_0, return_value_1, return_value_2)
+                    })
+                });
+            Ok(row_stream.into_stream())
         }
 
         #[derive(Debug, Clone, PartialEq)]
         pub struct Books {
             pub title: String,
         }
-        pub async fn books<T: GenericClient>(
+        pub async fn books<T: cornucopia_client::GenericClient>(
             client: &T,
-        ) -> Result<Vec<super::super::queries::module_2::Books>, Error> {
+        ) -> Result<Vec<super::super::queries::module_2::Books>, tokio_postgres::Error> {
+            use futures::{StreamExt, TryStreamExt};
             let stmt = client
                 .prepare(
                     "SELECT
@@ -88,27 +117,31 @@ Book;
 ",
                 )
                 .await?;
-            let res = client.query(&stmt, &[]).await?;
-
-            let return_value = res
-                .iter()
+            let res = client
+                .query_raw(&stmt, std::iter::empty::<i32>())
+                .await?
                 .map(|res| {
-                    let return_value_0: String = res.get(0);
-                    super::super::queries::module_2::Books {
-                        title: return_value_0,
-                    }
+                    res.map(|res| {
+                        let return_value_0: String = res.get(0);
+                        super::super::queries::module_2::Books {
+                            title: return_value_0,
+                        }
+                    })
                 })
-                .collect::<Vec<super::super::queries::module_2::Books>>();
-            Ok(return_value)
+                .try_collect()
+                .await?;
+            Ok(res)
         }
 
         #[derive(Debug, Clone, PartialEq)]
         pub struct BooksOptRetParam {
             pub title: Option<String>,
         }
-        pub async fn books_opt_ret_param<T: GenericClient>(
+        pub async fn books_opt_ret_param<T: cornucopia_client::GenericClient>(
             client: &T,
-        ) -> Result<Vec<super::super::queries::module_2::BooksOptRetParam>, Error> {
+        ) -> Result<Vec<super::super::queries::module_2::BooksOptRetParam>, tokio_postgres::Error>
+        {
+            use futures::{StreamExt, TryStreamExt};
             let stmt = client
                 .prepare(
                     "SELECT
@@ -118,24 +151,27 @@ Book;
 ",
                 )
                 .await?;
-            let res = client.query(&stmt, &[]).await?;
-
-            let return_value = res
-                .iter()
+            let res = client
+                .query_raw(&stmt, std::iter::empty::<i32>())
+                .await?
                 .map(|res| {
-                    let return_value_0: Option<String> = res.get(0);
-                    super::super::queries::module_2::BooksOptRetParam {
-                        title: return_value_0,
-                    }
+                    res.map(|res| {
+                        let return_value_0: Option<String> = res.get(0);
+                        super::super::queries::module_2::BooksOptRetParam {
+                            title: return_value_0,
+                        }
+                    })
                 })
-                .collect::<Vec<super::super::queries::module_2::BooksOptRetParam>>();
-            Ok(return_value)
+                .try_collect()
+                .await?;
+            Ok(res)
         }
 
-        pub async fn books_from_author_id<T: GenericClient>(
+        pub async fn books_from_author_id<T: cornucopia_client::GenericClient>(
             client: &T,
             id: &i32,
-        ) -> Result<Vec<String>, Error> {
+        ) -> Result<Vec<String>, tokio_postgres::Error> {
+            use futures::{StreamExt, TryStreamExt};
             let stmt = client
                 .prepare(
                     "SELECT
@@ -149,22 +185,24 @@ Author.Id = $1;
 ",
                 )
                 .await?;
-            let res = client.query(&stmt, &[&id]).await?;
-
-            let return_value = res
-                .iter()
-                .map(|row| {
-                    let value: String = row.get(0);
-                    value
+            let res = client
+                .query_raw(&stmt, &[&id])
+                .await?
+                .map(|res| {
+                    res.map(|row| {
+                        let value: String = row.get(0);
+                        value
+                    })
                 })
-                .collect::<Vec<String>>();
-            Ok(return_value)
+                .try_collect()
+                .await?;
+            Ok(res)
         }
 
-        pub async fn author_name_by_id_opt<T: GenericClient>(
+        pub async fn author_name_by_id_opt<T: cornucopia_client::GenericClient>(
             client: &T,
             id: &i32,
-        ) -> Result<Option<String>, Error> {
+        ) -> Result<Option<String>, tokio_postgres::Error> {
             let stmt = client
                 .prepare(
                     "SELECT
@@ -177,7 +215,6 @@ Author.Id = $1;
                 )
                 .await?;
             let res = client.query_opt(&stmt, &[&id]).await?;
-
             let return_value = res.map(|row| {
                 let value: String = row.get(0);
                 value
@@ -185,10 +222,10 @@ Author.Id = $1;
             Ok(return_value)
         }
 
-        pub async fn author_name_by_id<T: GenericClient>(
+        pub async fn author_name_by_id<T: cornucopia_client::GenericClient>(
             client: &T,
             id: &i32,
-        ) -> Result<String, Error> {
+        ) -> Result<String, tokio_postgres::Error> {
             let stmt = client
                 .prepare(
                     "SELECT
@@ -201,15 +238,15 @@ Author.Id = $1;
                 )
                 .await?;
             let res = client.query_one(&stmt, &[&id]).await?;
-
             let return_value: String = res.get(0);
             Ok(return_value)
         }
 
-        pub async fn author_name_starting_with<T: GenericClient>(
+        pub async fn author_name_starting_with<T: cornucopia_client::GenericClient>(
             client: &T,
             s: &str,
-        ) -> Result<Vec<(i32, String, i32, String)>, Error> {
+        ) -> Result<Vec<(i32, String, i32, String)>, tokio_postgres::Error> {
+            use futures::{StreamExt, TryStreamExt};
             let stmt = client
                 .prepare(
                     "SELECT
@@ -226,29 +263,31 @@ Author.Name LIKE CONCAT($1::text, '%');
 ",
                 )
                 .await?;
-            let res = client.query(&stmt, &[&s]).await?;
-
-            let return_value = res
-                .iter()
+            let res = client
+                .query_raw(&stmt, &[&s])
+                .await?
                 .map(|res| {
-                    let return_value_0: i32 = res.get(0);
-                    let return_value_1: String = res.get(1);
-                    let return_value_2: i32 = res.get(2);
-                    let return_value_3: String = res.get(3);
-                    (
-                        return_value_0,
-                        return_value_1,
-                        return_value_2,
-                        return_value_3,
-                    )
+                    res.map(|res| {
+                        let return_value_0: i32 = res.get(0);
+                        let return_value_1: String = res.get(1);
+                        let return_value_2: i32 = res.get(2);
+                        let return_value_3: String = res.get(3);
+                        (
+                            return_value_0,
+                            return_value_1,
+                            return_value_2,
+                            return_value_3,
+                        )
+                    })
                 })
-                .collect::<Vec<(i32, String, i32, String)>>();
-            Ok(return_value)
+                .try_collect()
+                .await?;
+            Ok(res)
         }
 
-        pub async fn return_custom_type<T: GenericClient>(
+        pub async fn return_custom_type<T: cornucopia_client::GenericClient>(
             client: &T,
-        ) -> Result<super::super::types::public::CustomComposite, Error> {
+        ) -> Result<super::super::types::public::CustomComposite, tokio_postgres::Error> {
             let stmt = client
                 .prepare(
                     "SELECT
@@ -259,15 +298,15 @@ CustomTable;
                 )
                 .await?;
             let res = client.query_one(&stmt, &[]).await?;
-
             let return_value: super::super::types::public::CustomComposite = res.get(0);
             Ok(return_value)
         }
 
-        pub async fn select_where_custom_type<T: GenericClient>(
+        pub async fn select_where_custom_type<T: cornucopia_client::GenericClient>(
             client: &T,
             spongebob_character: &super::super::types::public::SpongebobCharacter,
-        ) -> Result<super::super::types::public::SpongebobCharacter, Error> {
+        ) -> Result<super::super::types::public::SpongebobCharacter, tokio_postgres::Error>
+        {
             let stmt = client
                 .prepare(
                     "SELECT
@@ -279,14 +318,13 @@ WHERE (col1).persona = $1;
                 )
                 .await?;
             let res = client.query_one(&stmt, &[&spongebob_character]).await?;
-
             let return_value: super::super::types::public::SpongebobCharacter = res.get(0);
             Ok(return_value)
         }
 
-        pub async fn select_translations<T: GenericClient>(
+        pub async fn select_translations<T: cornucopia_client::GenericClient>(
             client: &T,
-        ) -> Result<Vec<String>, Error> {
+        ) -> Result<Vec<String>, tokio_postgres::Error> {
             let stmt = client
                 .prepare(
                     "SELECT
@@ -297,7 +335,6 @@ Book;
                 )
                 .await?;
             let res = client.query_one(&stmt, &[]).await?;
-
             let return_value: Vec<String> = res.get(0);
             Ok(return_value)
         }

--- a/grammar.pest
+++ b/grammar.pest
@@ -39,20 +39,19 @@ struct_return = {
 }
 return_type = _{ struct_return | implicit_return }
 
-// Special raw return
-raw_return = {"#"}
-
 // Query quantifier
+stream = {"#"}
 zero_or_more = {"*"}
 zero_or_one = {"?"}
 one = {""}
-quantifier = {zero_or_more | zero_or_one | one}
+quantifier = {zero_or_more | zero_or_one | stream | one}
 
 // Parser
 parser = {
     SOI 
 	~ ident 
     ~ parameter_list 
-    ~ (raw_return | (return_type ~ quantifier))
+    ~ return_type 
+    ~ quantifier
     ~ EOI
 }

--- a/grammar.pest
+++ b/grammar.pest
@@ -37,7 +37,10 @@ struct_return = {
     ~ comma?
     ~ end_ret_struct
 }
-return_type = _{(struct_return) | (implicit_return)}
+return_type = _{ struct_return | implicit_return }
+
+// Special raw return
+raw_return = {"#"}
 
 // Query quantifier
 zero_or_more = {"*"}
@@ -50,7 +53,6 @@ parser = {
     SOI 
 	~ ident 
     ~ parameter_list 
-    ~ return_type
-    ~ quantifier
+    ~ (raw_return | (return_type ~ quantifier))
     ~ EOI
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -67,6 +67,7 @@ fn healthcheck(podman: bool, max_retries: u64, ms_per_retry: u64) -> Result<(), 
             println!("Container startup slower than expected ({nb_retries} retries out of {max_retries})")
         }
     }
+    std::thread::sleep(std::time::Duration::from_millis(250));
     Ok(())
 }
 

--- a/src/integration/queries/module_1.sql
+++ b/src/integration/queries/module_1.sql
@@ -10,3 +10,7 @@ INSERT INTO Book (title)
 INSERT INTO Book (title)
   VALUES ('carl');
 
+--! insert_stream()#
+INSERT INTO Book (title)
+  VALUES ('dominic');
+

--- a/src/integration/queries/module_2.sql
+++ b/src/integration/queries/module_2.sql
@@ -4,9 +4,16 @@ SELECT
 FROM
     Author;
 
+--! authors_raw(name, country) #
+SELECT
+    *
+FROM
+    Author
+WHERE Author.Name = $1 AND Author.Country = $2;
+
 --! books() {title}*
 SELECT
-    Title::asd
+    Title
 FROM
     Book;
 

--- a/src/integration/queries/module_2.sql
+++ b/src/integration/queries/module_2.sql
@@ -4,12 +4,11 @@ SELECT
 FROM
     Author;
 
---! authors_raw(name, country) #
+--! authors_stream()#
 SELECT
     *
 FROM
-    Author
-WHERE Author.Name = $1 AND Author.Country = $2;
+    Author;
 
 --! books() {title}*
 SELECT

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -25,7 +25,6 @@ pub(crate) struct ParsedQueryMeta {
 pub(crate) enum ReturnType {
     Implicit,
     Explicit { params: Vec<ExplicitReturnParam> },
-    Raw,
 }
 
 #[derive(Debug)]
@@ -36,10 +35,10 @@ pub(crate) struct ExplicitReturnParam {
 
 #[derive(Debug)]
 pub(crate) enum Quantifier {
-    ZeroOrMore,
-    ZeroOrOne,
+    Vec,
+    Option,
     One,
-    Raw,
+    Stream,
 }
 
 pub(crate) fn parse_query_meta(meta: &str) -> Result<ParsedQueryMeta, Error> {
@@ -59,12 +58,8 @@ pub(crate) fn parse_query_meta(meta: &str) -> Result<ParsedQueryMeta, Error> {
     let return_tokens = parser_inner.next().unwrap();
     let ret = parse_return(return_tokens);
     // Parse quantifier
-    let quantifier = if let ReturnType::Raw = ret {
-        Quantifier::Raw
-    } else {
-        let quantifier_tokens = parser_inner.next().unwrap();
-        parse_quantifier(quantifier_tokens)
-    };
+    let quantifier_tokens = parser_inner.next().unwrap();
+    let quantifier = parse_quantifier(quantifier_tokens);
 
     Ok(ParsedQueryMeta {
         name,
@@ -103,16 +98,16 @@ fn parse_return(pair: Pair<Rule>) -> ReturnType {
                 .collect::<Vec<ExplicitReturnParam>>();
             ReturnType::Explicit { params }
         }
-        Rule::raw_return => ReturnType::Raw,
         _ => panic!(),
     }
 }
 
 fn parse_quantifier(pair: Pair<Rule>) -> Quantifier {
     match pair.into_inner().next().unwrap().as_rule() {
-        Rule::zero_or_more => Quantifier::ZeroOrMore,
-        Rule::zero_or_one => Quantifier::ZeroOrOne,
+        Rule::zero_or_more => Quantifier::Vec,
+        Rule::zero_or_one => Quantifier::Option,
         Rule::one => Quantifier::One,
+        Rule::stream => Quantifier::Stream,
         _ => panic!(),
     }
 }

--- a/src/pg_type.rs
+++ b/src/pg_type.rs
@@ -157,7 +157,7 @@ AND pg_namespace.nspname = $2;",
         client: &Client,
         oid: &u32,
     ) -> Result<Vec<String>, tokio_postgres::Error> {
-        let x = client
+        Ok(client
             .query(
                 "select e.enumlabel
 from pg_type t 
@@ -168,8 +168,7 @@ where t.oid = $1;",
             .await?
             .iter()
             .map(|row| row.get(0))
-            .collect::<Vec<String>>();
-        Ok(x)
+            .collect::<Vec<String>>())
     }
 
     async fn domain_base_type(
@@ -250,8 +249,6 @@ WHERE pg_type.typarray = $1;",
 
         let schema: String = row.get(0);
         let name: String = row.get(1);
-
-        //println!("{typtype} {typcategory}");
 
         Ok((schema, name))
     }

--- a/src/prepare_queries.rs
+++ b/src/prepare_queries.rs
@@ -33,7 +33,6 @@ pub(crate) enum RustReturnType {
     Scalar(CornucopiaType),
     Tuple(Vec<CornucopiaType>),
     Struct(Vec<(ExplicitReturnParam, CornucopiaType)>),
-    Raw,
 }
 
 pub(crate) async fn prepare_modules(
@@ -143,7 +142,6 @@ async fn prepare_query(
                     .collect::<Vec<(ExplicitReturnParam, CornucopiaType)>>();
                 RustReturnType::Struct(fields)
             }
-            ReturnType::Raw => RustReturnType::Raw,
         }
     };
 

--- a/src/prepare_queries.rs
+++ b/src/prepare_queries.rs
@@ -33,6 +33,7 @@ pub(crate) enum RustReturnType {
     Scalar(CornucopiaType),
     Tuple(Vec<CornucopiaType>),
     Struct(Vec<(ExplicitReturnParam, CornucopiaType)>),
+    Raw,
 }
 
 pub(crate) async fn prepare_modules(
@@ -142,6 +143,7 @@ async fn prepare_query(
                     .collect::<Vec<(ExplicitReturnParam, CornucopiaType)>>();
                 RustReturnType::Struct(fields)
             }
+            ReturnType::Raw => RustReturnType::Raw,
         }
     };
 


### PR DESCRIPTION
Closes #34.

The implementation is **not yet complete**, and as of now **incorrect** with respect to the changes proposed here
- [x] https://github.com/LouisGariepy/cornucopia/issues/34#issuecomment-1117381238 (returning a stream with strongly typed items, love it). 
- [x] https://github.com/LouisGariepy/cornucopia/issues/34#issuecomment-1117386309 (Improving queries returning vec to use `query_raw` to avoid unnecessary allocations).
- [x] I'll need to make sure the grammar also works with these changes, as I have assumed the "raw" identifier would be a "return_type", but now that we can strongly type the return stream, it would probably make a lot more sense to use it as a quantifier (as was originally proposed :) )